### PR TITLE
Fix: When a "emulatorAddress" is set, use it for the storage too 

### DIFF
--- a/lib/yust.dart
+++ b/lib/yust.dart
@@ -40,6 +40,8 @@ class Yust {
     );
 
     await FirebaseAuth.instance.useEmulator('http://$address:9099');
+
+    await FirebaseStorage.instance.useEmulator(host: address, port: 9199);
   }
 
   static Future<void> initialize({

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -35,7 +35,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -112,7 +112,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.2.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -308,7 +308,7 @@ packages:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.8.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -322,28 +322,28 @@ packages:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.1.0"
   firebase_storage:
     dependency: "direct main"
     description:
       name: firebase_storage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.0.3"
+    version: "8.1.3"
   firebase_storage_platform_interface:
     dependency: transitive
     description:
       name: firebase_storage_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.2"
   firebase_storage_web:
     dependency: transitive
     description:
       name: firebase_storage_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.1.2"
   fixnum:
     dependency: transitive
     description:
@@ -449,7 +449,7 @@ packages:
       name: image_picker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.4+2"
+    version: "0.8.4+1"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -526,7 +526,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.3.0"
   mime:
     dependency: "direct main"
     description:
@@ -825,7 +825,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.3.0"
   timing:
     dependency: transitive
     description:
@@ -932,5 +932,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
-  flutter: ">=2.5.0"
+  dart: ">=2.12.0 <3.0.0"
+  flutter: ">=2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   firebase_core: ^1.1.0
   firebase_auth: ^1.1.3
   cloud_firestore: ^2.0.0
-  firebase_storage: ^8.0.1
+  firebase_storage: ^8.1.0
 
   provider: ^5.0.0
   intl: ^0.17.0


### PR DESCRIPTION
The Version-Update to the Firebase Storage has no breaking changes and is needed for emulator support