### PR TITLE
Fix: Restore Emulator Connection

### DIFF
--- a/lib/src/services/yust_auth_service_dart.dart
+++ b/lib/src/services/yust_auth_service_dart.dart
@@ -4,7 +4,7 @@ import '../yust.dart';
 
 /// Handels auth request for Firebase Auth.
 class YustAuthService {
-  YustAuthService();
+  YustAuthService({String? emulatorAddress});
 
   YustAuthService.mocked();
 

--- a/lib/src/services/yust_auth_service_flutter.dart
+++ b/lib/src/services/yust_auth_service_flutter.dart
@@ -9,7 +9,12 @@ import '../yust.dart';
 class YustAuthService {
   FirebaseAuth fireAuth;
 
-  YustAuthService() : fireAuth = FirebaseAuth.instance;
+  YustAuthService({String? emulatorAddress})
+      : fireAuth = FirebaseAuth.instance {
+    if (emulatorAddress != null) {
+      fireAuth.useAuthEmulator(emulatorAddress, 9099);
+    }
+  }
 
   YustAuthService.mocked() : fireAuth = MockFirebaseAuth();
 

--- a/lib/src/services/yust_file_service_dart.dart
+++ b/lib/src/services/yust_file_service_dart.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 class YustFileService {
-  YustFileService();
+  YustFileService({String? emulatorAddress});
 
   YustFileService.mocked();
 

--- a/lib/src/services/yust_file_service_flutter.dart
+++ b/lib/src/services/yust_file_service_flutter.dart
@@ -10,7 +10,12 @@ import 'package:mime/mime.dart';
 import '../util/yust_exception.dart';
 
 class YustFileService {
-  YustFileService() : _fireStorage = firebase_storage.FirebaseStorage.instance;
+  YustFileService({String? emulatorAddress})
+      : _fireStorage = firebase_storage.FirebaseStorage.instance {
+    if (emulatorAddress != null) {
+      _fireStorage.useStorageEmulator(emulatorAddress, 9199);
+    }
+  }
 
   YustFileService.mocked() : _fireStorage = MockFirebaseStorage();
 

--- a/lib/src/util/firebase_helpers_dart.dart
+++ b/lib/src/util/firebase_helpers_dart.dart
@@ -40,7 +40,13 @@ class FirebaseHelpers {
       scopes,
     );
 
-    YustFirestoreApi.initialize(FirestoreApi(authClient), projectId: projectId);
+    YustFirestoreApi.initialize(
+      FirestoreApi(authClient,
+          rootUrl: emulatorAddress != null
+              ? "http://$emulatorAddress:8080/"
+              : 'https://firestore.googleapis.com/'),
+      projectId: projectId,
+    );
   }
 
   /// Converts a timestamp to a DateTime.

--- a/lib/src/util/firebase_helpers_flutter.dart
+++ b/lib/src/util/firebase_helpers_flutter.dart
@@ -27,15 +27,8 @@ class FirebaseHelpers {
 
     // Only use emulator when emulatorAddress is provided
     if (emulatorAddress != null) {
-      await _connectToFirebaseEmulator(emulatorAddress);
+      FirebaseFirestore.instance.useFirestoreEmulator(emulatorAddress, 8080);
     }
-  }
-
-  /// Connnect to the firebase emulator for Firestore and Authentication
-  static Future<void> _connectToFirebaseEmulator(String address) async {
-    FirebaseFirestore.instance.useFirestoreEmulator(address, 8080);
-
-    await FirebaseAuth.instance.useAuthEmulator(address, 9099);
   }
 
   static FirebaseOptions? fromMap(Map<String, String>? map) {

--- a/lib/src/yust.dart
+++ b/lib/src/yust.dart
@@ -70,8 +70,9 @@ class Yust {
     Yust.userSetup = userSetup ?? YustUser.setup;
     Yust.useSubcollections = useSubcollections;
     Yust.envCollectionName = envCollectionName;
-    Yust.authService = YustAuthService();
+    Yust.authService = YustAuthService(emulatorAddress: emulatorAddress);
+    // Note that the data connection for the emulator is handled in [initializeFirebase]
     Yust.databaseService = YustDatabaseService();
-    Yust.fileService = YustFileService();
+    Yust.fileService = YustFileService(emulatorAddress: emulatorAddress);
   }
 }


### PR DESCRIPTION
Since the major refactoring of yust, the it's not possible to connect to a firebase emulator.
This PR ensures the `emulatorAddress`-argument of `Yust.initialize` works as before.