### PR TITLE
Feature: Refactor Yust Statics

### DIFF
--- a/lib/src/models/yust_doc_setup.dart
+++ b/lib/src/models/yust_doc_setup.dart
@@ -2,6 +2,12 @@ import 'yust_doc.dart';
 
 /// The setup for a [YustDoc] is needed to read or save a document to the database.
 class YustDocSetup<T extends YustDoc> {
+  /// The ID of the tenant to use.
+  String? envId;
+
+  /// The id of the YustUser authoring this database action
+  String? userId;
+
   /// The name for the document collection.
   ///
   /// Example: An item should be saved in the collection 'items'.
@@ -13,14 +19,19 @@ class YustDocSetup<T extends YustDoc> {
   /// Callback to create a new document instance.
   T Function() newDoc;
 
-  /// If true the `userId` of the [YustDoc] will be automatically set when saving.
-  bool forUser;
+  ///Should be set to true if this setup is used for an environment.
+  bool isEnvironment;
 
   /// If true the [YustDoc] will be automatically saved in a subcollection under the tannant.
   bool forEnvironment;
 
-  ///Should be set to true if this setup is used for an environment.
-  bool isEnvironment;
+  /// If true the `userId` of the [YustDoc] will be automatically set when saving.
+  bool forUser;
+
+  /// If true the `createdBy` & `modifiedBy` of the [YustDoc] will be automatically set when saving.
+  ///
+  /// Disabling this makes sense, if the document isn't assigned to a user or generally not edited by users directly
+  bool hasAuthor;
 
   /// Should null values be removed, before writing the doc to the database.
   bool removeNullValues;
@@ -35,6 +46,9 @@ class YustDocSetup<T extends YustDoc> {
     required this.collectionName,
     required this.fromJson,
     required this.newDoc,
+    this.envId,
+    this.userId,
+    this.hasAuthor = false,
     this.forUser = false,
     this.forEnvironment = false,
     this.isEnvironment = false,

--- a/lib/src/models/yust_doc_setup.dart
+++ b/lib/src/models/yust_doc_setup.dart
@@ -56,4 +56,14 @@ class YustDocSetup<T extends YustDoc> {
     this.onSave,
     this.removeNullValues = true,
   });
+
+  @override
+  int get hashCode => Object.hash(collectionName, envId, userId);
+
+  @override
+  bool operator ==(Object other) =>
+      other is YustDocSetup &&
+      collectionName == other.collectionName &&
+      envId == other.envId &&
+      userId == other.userId;
 }

--- a/lib/src/models/yust_doc_setup.dart
+++ b/lib/src/models/yust_doc_setup.dart
@@ -26,6 +26,8 @@ class YustDocSetup<T extends YustDoc> {
   bool forEnvironment;
 
   /// If true the `userId` of the [YustDoc] will be automatically set when saving.
+  ///
+  /// Note that this, unlike [forEnvironment], doesn't set a filter for the userId
   bool forUser;
 
   /// If true the `createdBy` & `modifiedBy` of the [YustDoc] will be automatically set when saving.

--- a/lib/src/models/yust_doc_setup.dart
+++ b/lib/src/models/yust_doc_setup.dart
@@ -28,7 +28,7 @@ class YustDocSetup<T extends YustDoc> {
   /// If true the `userId` of the [YustDoc] will be automatically set when saving.
   ///
   /// Note that this, unlike [forEnvironment], doesn't set a filter for the userId
-  bool forUser;
+  bool hasOwner;
 
   /// If true the `createdBy` & `modifiedBy` of the [YustDoc] will be automatically set when saving.
   ///
@@ -51,7 +51,7 @@ class YustDocSetup<T extends YustDoc> {
     this.envId,
     this.userId,
     this.hasAuthor = false,
-    this.forUser = false,
+    this.hasOwner = false,
     this.forEnvironment = false,
     this.isEnvironment = false,
     this.onInit,

--- a/lib/src/models/yust_doc_setup.dart
+++ b/lib/src/models/yust_doc_setup.dart
@@ -38,6 +38,10 @@ class YustDocSetup<T extends YustDoc> {
   /// Should null values be removed, before writing the doc to the database.
   bool removeNullValues;
 
+  /// Should the database actions update the record specified by [hasAuthor] & [hasOwner].
+  /// Can be overriden in the db-calls directly e.g. [saveDoc].
+  bool trackModification;
+
   /// Callback when initialising a new [YustDoc].
   void Function(T doc)? onInit;
 
@@ -57,6 +61,7 @@ class YustDocSetup<T extends YustDoc> {
     this.onInit,
     this.onSave,
     this.removeNullValues = true,
+    this.trackModification = true,
   });
 
   @override

--- a/lib/src/models/yust_notification.dart
+++ b/lib/src/models/yust_notification.dart
@@ -10,11 +10,13 @@ dataFromJson(data) => Map<String, dynamic>.from(data);
 /// A representation of a push notification.
 @JsonSerializable()
 class YustNotification extends YustDoc {
-  static YustDocSetup<YustNotification> setup() =>
+  static YustDocSetup<YustNotification> setup(String userId) =>
       YustDocSetup<YustNotification>(
+        userId: userId,
         collectionName: 'notifications',
         newDoc: () => YustNotification(),
         fromJson: (json) => YustNotification.fromJson(json),
+        hasOwner: true,
       );
 
   String? forCollection;

--- a/lib/src/models/yust_notification.dart
+++ b/lib/src/models/yust_notification.dart
@@ -10,11 +10,11 @@ dataFromJson(data) => Map<String, dynamic>.from(data);
 /// A representation of a push notification.
 @JsonSerializable()
 class YustNotification extends YustDoc {
-  static final setup = YustDocSetup<YustNotification>(
-    collectionName: 'notifications',
-    newDoc: () => YustNotification(),
-    fromJson: (json) => YustNotification.fromJson(json),
-  );
+  static setup() => YustDocSetup<YustNotification>(
+        collectionName: 'notifications',
+        newDoc: () => YustNotification(),
+        fromJson: (json) => YustNotification.fromJson(json),
+      );
 
   String? forCollection;
   String? forDocId;

--- a/lib/src/models/yust_notification.dart
+++ b/lib/src/models/yust_notification.dart
@@ -10,7 +10,8 @@ dataFromJson(data) => Map<String, dynamic>.from(data);
 /// A representation of a push notification.
 @JsonSerializable()
 class YustNotification extends YustDoc {
-  static setup() => YustDocSetup<YustNotification>(
+  static YustDocSetup<YustNotification> setup() =>
+      YustDocSetup<YustNotification>(
         collectionName: 'notifications',
         newDoc: () => YustNotification(),
         fromJson: (json) => YustNotification.fromJson(json),

--- a/lib/src/models/yust_user.dart
+++ b/lib/src/models/yust_user.dart
@@ -9,11 +9,11 @@ part 'yust_user.g.dart';
 /// The user model.
 @JsonSerializable()
 class YustUser extends YustDoc {
-  static final setup = YustDocSetup<YustUser>(
-    collectionName: 'users',
-    newDoc: () => YustUser(email: '', firstName: '', lastName: ''),
-    fromJson: (json) => YustUser.fromJson(json),
-  );
+  static setup() => YustDocSetup<YustUser>(
+        collectionName: 'users',
+        newDoc: () => YustUser(email: '', firstName: '', lastName: ''),
+        fromJson: (json) => YustUser.fromJson(json),
+      );
 
   /// The email of the user.
   String email;

--- a/lib/src/models/yust_user.dart
+++ b/lib/src/models/yust_user.dart
@@ -9,7 +9,7 @@ part 'yust_user.g.dart';
 /// The user model.
 @JsonSerializable()
 class YustUser extends YustDoc {
-  static setup() => YustDocSetup<YustUser>(
+  static YustDocSetup<YustUser> setup() => YustDocSetup<YustUser>(
         collectionName: 'users',
         newDoc: () => YustUser(email: '', firstName: '', lastName: ''),
         fromJson: (json) => YustUser.fromJson(json),

--- a/lib/src/services/yust_auth_service_dart.dart
+++ b/lib/src/services/yust_auth_service_dart.dart
@@ -13,8 +13,7 @@ class YustAuthService {
     throw UnsupportedError('Not supported. No UI available.');
   }
 
-  /// Returns the ID of the user signed in.
-  String? get currUserId => null;
+  String? getCurrentUserId() => null;
 
   /// Sign in by email and password.
   Future<void> signIn(

--- a/lib/src/services/yust_auth_service_flutter.dart
+++ b/lib/src/services/yust_auth_service_flutter.dart
@@ -24,7 +24,7 @@ class YustAuthService {
     });
   }
 
-  String? get currUserId => fireAuth.currentUser?.uid;
+  String? getCurrentUserId() => fireAuth.currentUser?.uid;
 
   Future<void> signIn(
     String email,
@@ -70,7 +70,7 @@ class YustAuthService {
     );
     await userCredential.user!.updateEmail(email);
     final user = await Yust.databaseService
-        .getDocOnce<YustUser>(Yust.userSetup, currUserId!);
+        .getDocOnce<YustUser>(Yust.userSetup, fireAuth.currentUser!.uid);
     if (user != null) {
       user.email = email;
       await Yust.databaseService.saveDoc<YustUser>(Yust.userSetup, user);

--- a/lib/src/services/yust_database_service_dart.dart
+++ b/lib/src/services/yust_database_service_dart.dart
@@ -173,7 +173,7 @@ class YustDatabaseService {
     YustDocSetup<T> docSetup,
     T doc, {
     bool merge = true,
-    bool trackModification = true,
+    bool? trackModification,
     bool skipOnSave = false,
     bool? removeNullValues,
     List<String>? updateMask,

--- a/lib/src/services/yust_database_service_dart.dart
+++ b/lib/src/services/yust_database_service_dart.dart
@@ -291,7 +291,7 @@ class YustDatabaseService {
   String _getParentPath(YustDocSetup docSetup) {
     var parentPath = 'projects/$_projectId/databases/(default)/documents';
     if (Yust.useSubcollections && docSetup.forEnvironment) {
-      parentPath += '/${Yust.envCollectionName}/${Yust.currEnvId!}';
+      parentPath += '/${Yust.envCollectionName}/${docSetup.envId}';
     }
     if (docSetup.collectionName.contains('/')) {
       final nameParts = docSetup.collectionName.split('/');
@@ -341,7 +341,7 @@ class YustDatabaseService {
           fieldFilter: FieldFilter(
         field: FieldReference(fieldPath: 'envId'),
         op: 'EQUAL',
-        value: _valueToDbValue(Yust.currEnvId),
+        value: _valueToDbValue(docSetup.envId),
       )));
     }
     if (docSetup.forUser) {
@@ -349,7 +349,7 @@ class YustDatabaseService {
           fieldFilter: FieldFilter(
         field: FieldReference(fieldPath: 'userId'),
         op: 'EQUAL',
-        value: _valueToDbValue(Yust.authService.currUserId),
+        value: _valueToDbValue(docSetup.userId),
       )));
     }
     return result;

--- a/lib/src/services/yust_database_service_dart.dart
+++ b/lib/src/services/yust_database_service_dart.dart
@@ -344,14 +344,6 @@ class YustDatabaseService {
         value: _valueToDbValue(docSetup.envId),
       )));
     }
-    if (docSetup.forUser) {
-      result.add(Filter(
-          fieldFilter: FieldFilter(
-        field: FieldReference(fieldPath: 'userId'),
-        op: 'EQUAL',
-        value: _valueToDbValue(docSetup.userId),
-      )));
-    }
     return result;
   }
 

--- a/lib/src/services/yust_database_service_flutter.dart
+++ b/lib/src/services/yust_database_service_flutter.dart
@@ -114,7 +114,7 @@ class YustDatabaseService {
     YustDocSetup<T> docSetup,
     T doc, {
     bool? merge = true,
-    bool trackModification = true,
+    bool? trackModification,
     bool skipOnSave = false,
     bool? removeNullValues,
     List<String>? updateMask,

--- a/lib/src/services/yust_database_service_flutter.dart
+++ b/lib/src/services/yust_database_service_flutter.dart
@@ -227,7 +227,7 @@ class YustDatabaseService {
   String _getCollectionPath(YustDocSetup docSetup) {
     var collectionPath = '';
     if (Yust.useSubcollections && docSetup.forEnvironment) {
-      collectionPath += '${Yust.envCollectionName}/${Yust.currEnvId!}/';
+      collectionPath += '${Yust.envCollectionName}/${docSetup.envId}/';
     }
     collectionPath += docSetup.collectionName;
     return collectionPath;
@@ -255,19 +255,14 @@ class YustDatabaseService {
     YustDocSetup<T> docSetup,
   ) {
     if (!Yust.useSubcollections && docSetup.forEnvironment) {
-      query = _filterForEnvironment(query);
+      query = _filterForEnvironment(query, docSetup.envId!);
     }
-    if (docSetup.forUser) {
-      query = _filterForUser(query);
-    }
+
     return query;
   }
 
-  Query _filterForEnvironment(Query query) =>
-      query.where('envId', isEqualTo: Yust.currEnvId);
-
-  Query _filterForUser(Query query) =>
-      query.where('userId', isEqualTo: Yust.authService.currUserId);
+  Query _filterForEnvironment(Query query, String envId) =>
+      query.where('envId', isEqualTo: envId);
 
   Query _executeFilters(Query query, List<YustFilter>? filters) {
     if (filters != null) {

--- a/lib/src/services/yust_database_service_shared.dart
+++ b/lib/src/services/yust_database_service_shared.dart
@@ -13,7 +13,7 @@ Future<List<String>> prepareSaveDoc<T extends YustDoc>(
     updateMask.add('createdBy');
     doc.createdBy ??= doc.modifiedBy;
 
-    if (doc.userId == null && docSetup.forUser) {
+    if (doc.userId == null && docSetup.hasOwner) {
       updateMask.add('userId');
       doc.userId = docSetup.userId;
     }
@@ -50,7 +50,7 @@ T doInitDoc<T extends YustDoc>(YustDocSetup<T> docSetup, String id, [T? doc]) {
 
   if (docSetup.hasAuthor) {
     doc.createdBy = docSetup.userId;
-    if (docSetup.forUser) doc.userId = docSetup.userId;
+    if (docSetup.hasOwner) doc.userId = docSetup.userId;
   }
 
   if (docSetup.forEnvironment) {

--- a/lib/src/services/yust_database_service_shared.dart
+++ b/lib/src/services/yust_database_service_shared.dart
@@ -4,12 +4,12 @@ import '../models/yust_doc_setup.dart';
 Future<List<String>> prepareSaveDoc<T extends YustDoc>(
   YustDocSetup<T> docSetup,
   T doc, {
-  bool trackModification = true,
+  bool? trackModification,
   bool skipOnSave = false,
 }) async {
   final updateMask = <String>[];
 
-  if (trackModification) {
+  if (trackModification ?? docSetup.trackModification) {
     if (docSetup.hasAuthor) {
       updateMask.add('createdBy');
       doc.createdBy ??= doc.modifiedBy;

--- a/lib/src/services/yust_database_service_shared.dart
+++ b/lib/src/services/yust_database_service_shared.dart
@@ -9,28 +9,28 @@ Future<List<String>> prepareSaveDoc<T extends YustDoc>(
 }) async {
   final updateMask = <String>[];
 
-  if (docSetup.hasAuthor) {
-    updateMask.add('createdBy');
-    doc.createdBy ??= doc.modifiedBy;
+  if (trackModification) {
+    if (docSetup.hasAuthor) {
+      updateMask.add('createdBy');
+      doc.createdBy ??= doc.modifiedBy;
 
-    if (doc.userId == null && docSetup.hasOwner) {
+      updateMask.add('modifiedBy');
+      doc.modifiedBy = docSetup.userId;
+    }
+
+    if (docSetup.hasOwner && doc.userId == null) {
       updateMask.add('userId');
       doc.userId = docSetup.userId;
     }
 
-    if (trackModification) {
-      updateMask.add('modifiedBy');
-      doc.modifiedBy = docSetup.userId;
-    }
-  }
-
-  if (trackModification) {
     updateMask.add('modifiedAt');
     doc.modifiedAt = DateTime.now();
   }
 
-  updateMask.add('createdAt');
-  doc.createdAt ??= doc.modifiedAt;
+  if (doc.createdAt == null) {
+    updateMask.add('createdAt');
+    doc.createdAt ??= doc.modifiedAt;
+  }
 
   if (doc.envId == null && docSetup.forEnvironment) {
     updateMask.add('envId');
@@ -48,14 +48,9 @@ T doInitDoc<T extends YustDoc>(YustDocSetup<T> docSetup, String id, [T? doc]) {
   doc.id = id;
   doc.createdAt = DateTime.now();
 
-  if (docSetup.hasAuthor) {
-    doc.createdBy = docSetup.userId;
-    if (docSetup.hasOwner) doc.userId = docSetup.userId;
-  }
-
-  if (docSetup.forEnvironment) {
-    doc.envId = docSetup.envId;
-  }
+  if (docSetup.hasAuthor) doc.createdBy = docSetup.userId;
+  if (docSetup.hasOwner) doc.userId = docSetup.userId;
+  if (docSetup.forEnvironment) doc.envId = docSetup.envId;
 
   docSetup.onInit?.call(doc);
 

--- a/lib/src/util/mock_database.dart
+++ b/lib/src/util/mock_database.dart
@@ -72,7 +72,7 @@ class MockDatabase {
     YustDocSetup<T> docSetup,
     T doc, {
     bool merge = true,
-    bool trackModification = true,
+    bool? trackModification,
     bool skipOnSave = false,
     bool? removeNullValues,
   }) async {

--- a/lib/src/yust.dart
+++ b/lib/src/yust.dart
@@ -33,9 +33,6 @@ class Yust {
   /// Represents the collection name for the tannants.
   static String envCollectionName = 'envs';
 
-  /// The ID of the current tannant in use.
-  static String? currEnvId;
-
   /// Initializes [Yust] with mocked services for testing.
   ///
   /// This method should be called before any usage of the yust package.
@@ -67,7 +64,7 @@ class Yust {
       buildRelease: buildRelease,
     );
 
-    Yust.userSetup = userSetup ?? YustUser.setup;
+    Yust.userSetup = userSetup ?? YustUser.setup();
     Yust.useSubcollections = useSubcollections;
     Yust.envCollectionName = envCollectionName;
     Yust.authService = YustAuthService();


### PR DESCRIPTION
At the moment Yust has some static variables which prevent using one yust-package for multiple workspaces & users in parallel.

This PR changes the following:
- Removes the static variables `currEnvId` & `currUserId`
- Adds those removed statics to the `YustDocSetup` (as `envId` & `userId`)
- Refactors the `YustDoc.setup` to be a Function. This function can be used by developers to dynamically pass `envId` & `userId` when creating the `YustDocSetup` for a `YustDoc`-Supertype
- Adds a new Field `hasAuthor` to the `YustDocSetup`, which decides if the fields `createdBy` & `modifiedBy`should be filled in. E.g. `YustNotification`s are not created "by" a user, therefore these fields make no sense there. The field will co-exist with the `forUser`-field which still decides if the `userId`-field should be filled in: E.g. when a User owns the Document
- Overrides the `hashCode` & `==` Methods for the `YustDocSetup`, so devolpers can easily compare if the "type" of the YustDoc queried/to be created/etc. has change, even if different instances were created.

Please merge this [YustUI-PR](https://d51.tech/PRWS) as well.