### PR TITLE
Fix: Error Handling for invalid Records

### DIFF
--- a/lib/src/services/yust_database_service_dart.dart
+++ b/lib/src/services/yust_database_service_dart.dart
@@ -175,6 +175,7 @@ class YustDatabaseService {
   ///
   /// If [merge] is false a document with the same name
   /// will be overwritten instead of trying to merge the data.
+  /// Use [doNotCreate] to ensure that no new record is created
   Future<void> saveDoc<T extends YustDoc>(
     YustDocSetup<T> docSetup,
     T doc, {
@@ -184,6 +185,7 @@ class YustDatabaseService {
     bool? removeNullValues,
     List<String>? updateMask,
     bool skipLog = false,
+    bool doNotCreate = false,
   }) async {
     final yustUpdateMask = await prepareSaveDoc(docSetup, doc,
         trackModification: trackModification, skipOnSave: skipOnSave);
@@ -194,7 +196,8 @@ class YustDatabaseService {
           merge: merge,
           trackModification: trackModification,
           skipOnSave: skipOnSave,
-          removeNullValues: removeNullValues);
+          removeNullValues: removeNullValues,
+          doNotCreate: doNotCreate);
     }
     if (!skipLog) dbLogCallback?.call(DatabaseLogAction.save, docSetup, 1);
     final jsonDoc = doc.toJson();
@@ -213,6 +216,7 @@ class YustDatabaseService {
       dbDoc,
       _getDocumentPath(docSetup, doc.id),
       updateMask_fieldPaths: quotedUpdateMask,
+      currentDocument_exists: doNotCreate ? true : null,
     );
   }
 

--- a/lib/src/services/yust_database_service_dart.dart
+++ b/lib/src/services/yust_database_service_dart.dart
@@ -480,7 +480,13 @@ class YustDatabaseService {
       return null;
     }
 
-    return docSetup.fromJson(json);
+    try {
+      return docSetup.fromJson(json);
+    } catch (e) {
+      print(
+          '[[WARNING]] Error Transforming JSON. Collection ${docSetup.collectionName}, Workspace ${docSetup.envId}: $e ($json)');
+      return null;
+    }
   }
 
   Value _valueToDbValue(dynamic value) {

--- a/lib/src/services/yust_database_service_flutter.dart
+++ b/lib/src/services/yust_database_service_flutter.dart
@@ -369,7 +369,12 @@ class YustDatabaseService {
         }
         return currentNode.value;
       });
-      return docSetup.fromJson(modifiedData);
+      try {
+        return docSetup.fromJson(modifiedData);
+      } catch (e) {
+        print('[[WARNING]] Error Transforming JSON $e');
+        return null;
+      }
     }
     return null;
   }

--- a/lib/src/services/yust_database_service_flutter.dart
+++ b/lib/src/services/yust_database_service_flutter.dart
@@ -122,6 +122,7 @@ class YustDatabaseService {
     bool skipOnSave = false,
     bool? removeNullValues,
     List<String>? updateMask,
+    bool doNotCreate = false,
   }) async {
     var collection = _fireStore.collection(_getCollectionPath(docSetup));
     final yustUpdateMask = await prepareSaveDoc(docSetup, doc,
@@ -137,6 +138,7 @@ class YustDatabaseService {
       jsonDoc,
       removeNullValues: removeNullValues ?? docSetup.removeNullValues,
     );
+    // TODO: Support doNotCreate
     await collection
         .doc(doc.id)
         .set(modifiedDoc, SetOptions(merge: merge, mergeFields: updateMask));

--- a/lib/src/util/mock_database.dart
+++ b/lib/src/util/mock_database.dart
@@ -75,9 +75,10 @@ class MockDatabase {
     bool? trackModification,
     bool skipOnSave = false,
     bool? removeNullValues,
+    bool doNotCreate = false,
   }) async {
     final docs = _getCollection<T>(docSetup.collectionName);
-    if (!docs.contains(doc)) {
+    if (!doNotCreate && !docs.contains(doc)) {
       docs.add(doc);
     }
   }


### PR DESCRIPTION
- Catches errors during fromJson conversion of database records. Deletes them from the result set. (Flutter & Dart)
- Adds a new paramter to saveDoc `doNotCreate`, which -- if true -- ensures that the save will only update an existing document and not create a new one (dart-only for now)