### PR TITLE
Feature: Add getDocsChunked-Method

### DIFF
--- a/lib/src/services/yust_database_service_dart.dart
+++ b/lib/src/services/yust_database_service_dart.dart
@@ -116,6 +116,9 @@ class YustDatabaseService {
   /// 3. It doesn't use the google_apis package for the request, because that
   ///    has a huge memory leak
   ///
+  /// NOTE: Because this is a Stream you may only iterate over it once,
+  /// listing to it multiple times will result in a runtime-exception!
+  ///
   /// [docSetup] is used to read the collection path.
   ///
   /// [filters] each entry represents a condition that has to be met.

--- a/lib/src/services/yust_database_service_flutter.dart
+++ b/lib/src/services/yust_database_service_flutter.dart
@@ -181,6 +181,18 @@ class YustDatabaseService {
     return modifiedObj;
   }
 
+  /// NOTE: This method has no use in frontend
+  Stream<T> getDocsChunked<T extends YustDoc>(
+    YustDocSetup<T> docSetup, {
+    List<YustFilter>? filters,
+    List<String>? orderByList,
+    int pageSize = 5000,
+  }) {
+    return Stream.fromFuture(
+            getDocsOnce(docSetup, filters: filters, orderByList: orderByList))
+        .expand((e) => e);
+  }
+
   Future<void> deleteDocs<T extends YustDoc>(
     YustDocSetup<T> docSetup, {
     List<YustFilter>? filters,

--- a/lib/src/util/firebase_helpers_dart.dart
+++ b/lib/src/util/firebase_helpers_dart.dart
@@ -51,13 +51,11 @@ class FirebaseHelpers {
       print('Current GCP project id: $projectId');
     }
 
-    final api = FirestoreApi(authClient,
-        rootUrl: emulatorAddress != null
-            ? 'http://$emulatorAddress:8080/'
-            : 'https://firestore.googleapis.com/');
-
     YustFirestoreApi.initialize(
-      api,
+      authClient,
+      emulatorAddress != null
+          ? 'http://$emulatorAddress:8080/'
+          : 'https://firestore.googleapis.com/',
       projectId: projectId,
     );
   }

--- a/lib/src/util/yust_firestore_api.dart
+++ b/lib/src/util/yust_firestore_api.dart
@@ -1,11 +1,17 @@
 import 'package:googleapis/firestore/v1.dart';
+import 'package:googleapis_auth/auth_io.dart';
 
 class YustFirestoreApi {
   static FirestoreApi? instance;
   static String? projectId;
+  static String rootUrl = 'https://firestore.googleapis.com/';
+  static AutoRefreshingAuthClient? httpClient;
 
-  static void initialize(FirestoreApi firestoreApi, {String? projectId}) {
-    instance = firestoreApi;
+  static void initialize(AutoRefreshingAuthClient httpClient, String rootUrl,
+      {String? projectId}) {
+    YustFirestoreApi.httpClient = httpClient;
+    YustFirestoreApi.rootUrl = rootUrl;
+    YustFirestoreApi.instance = FirestoreApi(httpClient, rootUrl: rootUrl);
     YustFirestoreApi.projectId = projectId;
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -610,7 +610,7 @@ packages:
     source: hosted
     version: "2.1.0"
   stream_transform:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: stream_transform
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   intl: ^0.17.0
   mime: ^1.0.0
   timezone: ^0.9.0
+  stream_transform: ^2.1.0
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
To handle large datasets (30k+) with a relativly low memory footprint, this PR adds a new getDocsChunked-Method. It does the following (copied from it's doc string): 

```
Returns [YustDoc]s as a lazy, chunked Stream from the database.

 This is much more memory efficient in comparison to other methods,
 because of three reasons:
 1. It gets the data in multiple requests ([pageSize] each); the raw json
    strings and raw maps are only in memory while one chunk is processed.
 2. It loads the records *lazily*, meaning only one chunk is in memory while
    the records worked with (e.g. via a `await for(...)`)
 3. It doesn't use the google_apis package for the request, because that
    has a huge memory leak
```

It can conviently be used with `async for`-Loops to replace `getDocsOnce`.