### PR TITLE
Fix: Round doubles & adds more information to DB logs

### DIFF
--- a/lib/src/services/yust_database_service_dart.dart
+++ b/lib/src/services/yust_database_service_dart.dart
@@ -266,7 +266,10 @@ class YustDatabaseService {
           removeNullValues: removeNullValues,
           doNotCreate: doNotCreate);
     }
-    if (!skipLog) dbLogCallback?.call(DatabaseLogAction.save, docSetup, 1);
+    if (!skipLog) {
+      dbLogCallback?.call(DatabaseLogAction.save, docSetup, 1,
+          id: doc.id, updateMask: updateMask ?? []);
+    }
     final jsonDoc = doc.toJson();
     final dbDoc = Document(
         fields:
@@ -309,7 +312,8 @@ class YustDatabaseService {
         transform: documentTransform,
         currentDocument: Precondition(exists: true));
     final commitRequest = CommitRequest(writes: [write]);
-    dbLogCallback?.call(DatabaseLogAction.transform, docSetup, 1);
+    dbLogCallback?.call(DatabaseLogAction.transform, docSetup, 1,
+        id: id, updateMask: fieldTransforms.map((e) => e.fieldPath).toList());
 
     await _api.projects.databases.documents.commit(
       commitRequest,

--- a/lib/src/services/yust_database_service_dart.dart
+++ b/lib/src/services/yust_database_service_dart.dart
@@ -583,7 +583,8 @@ class YustDatabaseService {
     } else if (value is int) {
       return Value(integerValue: value.toString());
     } else if (value is double) {
-      return Value(doubleValue: value);
+      // Round double values
+      return Value(doubleValue: Yust.helpers.roundToDecimalPlaces(value));
     } else if (value == null) {
       return Value(nullValue: 'NULL_VALUE');
     } else if (value is String && value.isIso8601String) {
@@ -621,7 +622,7 @@ class YustDatabaseService {
     } else if (dbValue.integerValue != null) {
       return int.parse(dbValue.integerValue!);
     } else if (dbValue.doubleValue != null) {
-      return dbValue.doubleValue;
+      return Yust.helpers.roundToDecimalPlaces(dbValue.doubleValue!);
     } else if (dbValue.nullValue != null) {
       return null;
     } else if (dbValue.stringValue != null) {

--- a/lib/src/services/yust_database_service_flutter.dart
+++ b/lib/src/services/yust_database_service_flutter.dart
@@ -164,17 +164,24 @@ class YustDatabaseService {
     bool removeNullValues = true,
   }) {
     final modifiedObj = TraverseObject.traverseObject(obj, (currentNode) {
+      // Remove null'ed values from map
       if (removeNullValues &&
           !currentNode.info.isInList &&
           currentNode.value == null) {
         return FieldValue.delete();
       }
+      // Parse dart DateTimes
       if (currentNode.value is DateTime) {
         return Timestamp.fromDate(currentNode.value);
       }
+      // Parse ISO Timestamp Strings
       if (currentNode.value is String &&
           (currentNode.value as String).isIso8601String) {
         return Timestamp.fromDate(DateTime.parse(currentNode.value));
+      }
+      // Round double values
+      if (currentNode.value is double) {
+        return Yust.helpers.roundToDecimalPlaces(currentNode.value);
       }
       return currentNode.value;
     });
@@ -381,6 +388,11 @@ class YustDatabaseService {
               .toDate()
               .toUtc()
               .toIso8601String();
+        }
+
+        // Round double values
+        if (currentNode.value is double) {
+          return Yust.helpers.roundToDecimalPlaces(currentNode.value);
         }
         return currentNode.value;
       });

--- a/lib/src/util/yust_helpers.dart
+++ b/lib/src/util/yust_helpers.dart
@@ -113,4 +113,14 @@ class YustHelpers {
   Duration dateDifference(DateTime? first, DateTime? second) => Duration(
       milliseconds: (first?.millisecondsSinceEpoch ?? 0) -
           (second?.millisecondsSinceEpoch ?? 0));
+
+  /// Rounds a number to the given amount of decimal places
+  ///
+  /// NOTE: This does multiply the number by 10^[fractionalDigits], so make sure
+  /// the input number is smaller than 2^(53 - [fractionalDigits]) - 1$,
+  /// e.g. for the default 8 digits: 35,184,372,088,831.
+  /// See https://dart.dev/guides/language/numbers#precision for more details
+  double roundToDecimalPlaces(num value, [int fractionalDigits = 8]) =>
+      (value * pow(10, fractionalDigits + 1)).roundToDouble() /
+      pow(10, fractionalDigits + 1);
 }

--- a/lib/src/yust.dart
+++ b/lib/src/yust.dart
@@ -29,10 +29,8 @@ enum DatabaseLogAction {
 }
 
 typedef DatabaseLogCallback = void Function(
-  DatabaseLogAction action,
-  YustDocSetup setup,
-  int count,
-);
+    DatabaseLogAction action, YustDocSetup setup, int count,
+    {String? id, List<String>? updateMask});
 
 /// Yust is the easiest way to connect full stack Dart app to Firebase.
 ///


### PR DESCRIPTION
- Rounds all doubles coming from & getting to the database to 8 fractional digits
- Adds `id` & `updateMask` to the `dbLogCallback` for `saveDoc` and `updateDocByTransform`. This allows for better debugging with the information given in a log entry.
