### PR TITLE
Fix database service mocked

### DIFF
--- a/lib/src/services/yust_database_service_mocked.dart
+++ b/lib/src/services/yust_database_service_mocked.dart
@@ -45,10 +45,10 @@ class YustDatabaseServiceMocked extends YustDatabaseService {
     String id,
   ) async {
     final docs = _getCollection<T>(docSetup);
-    if (docs.isEmpty) {
-      return null;
-    } else {
+    try {
       return docs.firstWhere((doc) => doc.id == id);
+    } catch (e) {
+      return null;
     }
   }
 

--- a/lib/src/services/yust_database_service_mocked.dart
+++ b/lib/src/services/yust_database_service_mocked.dart
@@ -245,8 +245,8 @@ class YustDatabaseServiceMocked extends YustDatabaseService {
     T doc,
   ) async {
     await doc.onDelete();
-    final docs = _getCollection<T>(docSetup);
-    docs.remove(doc);
+    final jsonDocs = _getJSONCollection(docSetup.collectionName);
+    jsonDocs.removeWhere((d) => d['id'] == doc.id);
     await onChange?.call(
       _getParentPath(docSetup, doc: doc),
       doc.toJson(),
@@ -257,10 +257,11 @@ class YustDatabaseServiceMocked extends YustDatabaseService {
   @override
   Future<void> deleteDocById<T extends YustDoc>(
       YustDocSetup<T> docSetup, String docId) async {
-    await (await get(docSetup, docId))?.onDelete();
-    final docs = _getCollection<T>(docSetup);
-    final doc = docs.firstWhere((doc) => doc.id == docId);
-    docs.remove(doc);
+    final doc = await get(docSetup, docId);
+    if (doc == null) return;
+    await doc.onDelete();
+    final jsonDocs = _getJSONCollection(docSetup.collectionName);
+    jsonDocs.removeWhere((d) => d['id'] == docId);
     await onChange?.call(
       _getParentPath(docSetup, doc: doc),
       doc.toJson(),


### PR DESCRIPTION
Fixes in `database_service_mocked.dart`:
 - get methods should return null if not found and not throw
 - delete methods should work