### PR TITLE
Fix: Fix Jumps in Paginated List View

### DIFF
--- a/lib/src/util/google_cloud_helpers_flutter.dart
+++ b/lib/src/util/google_cloud_helpers_flutter.dart
@@ -30,6 +30,16 @@ class GoogleCloudHelpers {
     if (emulatorAddress != null) {
       FirebaseFirestore.instance.useFirestoreEmulator(emulatorAddress, 8080);
     }
+
+    // Set Cache Options
+    if (kIsWeb) {
+      await FirebaseFirestore.instance
+          // Have one Cache over all univelop tabs (IndexDB)
+          .enablePersistence(const PersistenceSettings(synchronizeTabs: true));
+    } else {
+      FirebaseFirestore.instance.settings =
+          const Settings(persistenceEnabled: true);
+    }
   }
 
   static FirebaseOptions? fromMap(Map<String, String>? map) {


### PR DESCRIPTION
Fixes a "jump" to starting scroll position in the `YustPaginatedListView`.

This is done by something apparently unrelated: Setting an more advanced Caching Behavior in the Browser. 

Which fixes the bug, because the jump to start of scroll position is actually just a shorting of the displayed list to one item, and then extending it again. And this happens because when updating the queries limit after scrolling down (to fetch more items from the backend), the cache will immediatly response with it's one cached item (the selected record), which the `FirestoreListView` interpretes as only one item existing. A few milliseconds later the real backend replies and provides the full list. By allowing for a "real" caching in web the cache will return the full list from the beginging, and not only the selected record, therefore having a jump in Scroll Location.