### PR TITLE
replace + in name upon sign up

### DIFF
--- a/lib/src/services/yust_auth_service_flutter.dart
+++ b/lib/src/services/yust_auth_service_flutter.dart
@@ -102,7 +102,8 @@ class YustAuthService {
   String _getEmail(UserCredential userCredential) =>
       userCredential.user!.email ?? '';
 
-  String _getFirstName(List<String> nameParts) => nameParts.join(' ');
+  String _getFirstName(List<String> nameParts) =>
+      nameParts.join(' ').replaceAll(r'+', ' ');
 
   String _getLastName(List<String> nameParts) => nameParts.removeLast();
 


### PR DESCRIPTION
for some reason Apple puts a '+' in the first name if the first name is longer than one word