### PR TITLE
feat: support backend JWT generation in YustAuthService

### DIFF
--- a/lib/src/services/yust_auth_service_dart.dart
+++ b/lib/src/services/yust_auth_service_dart.dart
@@ -316,13 +316,7 @@ class YustAuthService {
     String? subjectServiceAccountMail = overrideEmail;
     Map? serviceAccountKey;
 
-    // ignore: avoid_print
-    print(
-      '[YustAuthService] getAuthTokenForAuthId: authId=$authId, pathToServiceAccountJson=$_pathToServiceAccountJson',
-    );
     if (_pathToServiceAccountJson != null) {
-      // ignore: avoid_print
-      print('[YustAuthService] getAuthTokenForAuthId: using SA JSON file');
       final rawFileText = await File(_pathToServiceAccountJson).readAsString();
       final decodedKey = jsonDecode(rawFileText);
 
@@ -332,47 +326,24 @@ class YustAuthService {
       serviceAccountKey = decodedKey;
       subjectServiceAccountMail ??= serviceAccountKey['client_email'];
       issuerAccountMail = serviceAccountKey['client_email'];
-      // ignore: avoid_print
-      print(
-        '[YustAuthService] getAuthTokenForAuthId: SA email=$issuerAccountMail',
-      );
+
       // If we got a service account key file, we can just use the private key provided
       // for signing.
-      // ignore: avoid_print
-      print(
-        '[YustAuthService] getAuthTokenForAuthId: creating unsigned JWT for authId=$authId subject=${subjectServiceAccountMail ?? issuerAccountMail} issuer=$issuerAccountMail targetUrl=$targetUrl',
-      );
       final jwt = _createUnsignedJWTForAuthId(
         authId,
         subjectServiceAccountMail ?? issuerAccountMail,
         issuerAccountMail,
         targetUrl: targetUrl,
       );
-      // ignore: avoid_print
-      print(
-        '[YustAuthService] getAuthTokenForAuthId: signing JWT with RSA private key',
-      );
       final signedJwt = jwt.sign(
         RSAPrivateKey(serviceAccountKey['private_key']),
         algorithm: JWTAlgorithm.RS256,
         expiresIn: const Duration(seconds: 3600),
       );
-      // ignore: avoid_print
-      print(
-        '[YustAuthService] getAuthTokenForAuthId: signed custom token with SA key file',
-      );
       return signedJwt;
     } else {
       try {
-        // ignore: avoid_print
-        print(
-          '[YustAuthService] getAuthTokenForAuthId: fetching SA email from metadata server',
-        );
         final metadataEmail = await _getServiceAccountEmailFromMetadata();
-        // ignore: avoid_print
-        print(
-          '[YustAuthService] getAuthTokenForAuthId: using IAM path, metadata email=$metadataEmail',
-        );
         subjectServiceAccountMail ??= metadataEmail;
         issuerAccountMail = metadataEmail;
 
@@ -389,10 +360,6 @@ class YustAuthService {
           'iat': DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000,
           'exp': (DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000) + 3600,
         });
-        // ignore: avoid_print
-        print(
-          '[YustAuthService] getAuthTokenForAuthId: calling IAM signJwt delegate=$delegate payload=$payload',
-        );
         final signRequest = SignJwtRequest(payload: payload);
         final SignJwtResponse signingResponse;
         try {
@@ -407,10 +374,7 @@ class YustAuthService {
         if (signedJwt == null) {
           throw YustException('Could not sign JWT');
         }
-        // ignore: avoid_print
-        print(
-          '[YustAuthService] getAuthTokenForAuthId: IAM signed custom token successfully',
-        );
+
         return signedJwt;
       } catch (e) {
         throw YustException(
@@ -434,20 +398,12 @@ class YustAuthService {
   /// If [targetUrl] is provided, it is embedded as a `resource` claim so the
   /// token is bound to that URL (validated server-side by the API middleware).
   Future<String?> getJWTToken({String? targetUrl}) async {
-    // ignore: avoid_print
-    print(
-      '[YustAuthService] getJWTToken: backendAuthId=$_backendAuthId, targetUrl=$targetUrl, pathToServiceAccountJson=$_pathToServiceAccountJson',
-    );
     if (_backendAuthId == null) {
       throw UnsupportedError('Not supported. No UI available.');
     }
     final customToken = await getAuthTokenForAuthId(
       _backendAuthId,
       targetUrl: targetUrl,
-    );
-    // ignore: avoid_print
-    print(
-      '[YustAuthService] getJWTToken: got custom token, exchanging for ID token',
     );
     final response = await _api.accounts.signInWithCustomToken(
       GoogleCloudIdentitytoolkitV1SignInWithCustomTokenRequest(
@@ -458,8 +414,6 @@ class YustAuthService {
     if (response.idToken == null) {
       throw YustException('Failed to get ID token from custom token exchange');
     }
-    // ignore: avoid_print
-    print('[YustAuthService] getJWTToken: successfully obtained ID token');
     return response.idToken;
   }
 

--- a/lib/src/services/yust_auth_service_dart.dart
+++ b/lib/src/services/yust_auth_service_dart.dart
@@ -20,12 +20,21 @@ class YustAuthService {
   final Yust _yust;
   final String? _pathToServiceAccountJson;
 
+  /// The Firebase Auth ID (uid) used to generate tokens for backend-to-backend
+  /// API calls. When set, [getJWTToken] signs in as this user via a custom
+  /// token exchange instead of throwing [UnsupportedError].
+  ///
+  /// On the backend this is typically the admin service account uid.
+  final String? _backendAuthId;
+
   YustAuthService(
     Yust yust, {
     String? emulatorAddress,
     String? pathToServiceAccountJson,
+    String? backendAuthId,
   }) : _yust = yust,
        _pathToServiceAccountJson = pathToServiceAccountJson,
+       _backendAuthId = backendAuthId,
        _api = emulatorAddress != null
            ? IdentityToolkitApi(
                Yust.authClient!,
@@ -262,10 +271,14 @@ class YustAuthService {
   JWT _createUnsignedJWTForAuthId(
     String authId,
     String subjectAccountMail,
-    String issuerAccountMail,
-  ) {
+    String issuerAccountMail, {
+    String? targetUrl,
+  }) {
     return JWT(
-      {'uid': authId},
+      {
+        'uid': authId,
+        if (targetUrl != null) 'claims': {'resource': targetUrl},
+      },
       subject: subjectAccountMail,
       issuer: issuerAccountMail,
       header: {'alg': 'RS256', 'typ': 'JWT'},
@@ -287,18 +300,29 @@ class YustAuthService {
 
   /// Get a valid sign in token for a given auth Id
   ///
-  ///  If a Service Account File exists (e.g. in tools & emulator),
-  /// we private key & email from the file to create the JWT.
-  /// Else we use credentials from the cloud run environment
+  /// If a Service Account File exists (e.g. in tools & emulator),
+  /// we use the private key & email from the file to create the JWT.
+  /// Else we use credentials from the Cloud Run environment.
+  ///
+  /// If [targetUrl] is provided, it is embedded as a `resource` custom claim
+  /// in the JWT. Firebase copies `claims.*` into the resulting ID token, so
+  /// the API server can validate the claim to restrict the token to that URL.
   Future<String> getAuthTokenForAuthId(
     String authId, {
     String? overrideEmail,
+    String? targetUrl,
   }) async {
     String issuerAccountMail;
     String? subjectServiceAccountMail = overrideEmail;
     Map? serviceAccountKey;
 
+    // ignore: avoid_print
+    print(
+      '[YustAuthService] getAuthTokenForAuthId: authId=$authId, pathToServiceAccountJson=$_pathToServiceAccountJson',
+    );
     if (_pathToServiceAccountJson != null) {
+      // ignore: avoid_print
+      print('[YustAuthService] getAuthTokenForAuthId: using SA JSON file');
       final rawFileText = await File(_pathToServiceAccountJson).readAsString();
       final decodedKey = jsonDecode(rawFileText);
 
@@ -308,40 +332,68 @@ class YustAuthService {
       serviceAccountKey = decodedKey;
       subjectServiceAccountMail ??= serviceAccountKey['client_email'];
       issuerAccountMail = serviceAccountKey['client_email'];
+      // ignore: avoid_print
+      print(
+        '[YustAuthService] getAuthTokenForAuthId: SA email=$issuerAccountMail',
+      );
       // If we got a service account key file, we can just use the private key provided
       // for signing.
+      // ignore: avoid_print
+      print(
+        '[YustAuthService] getAuthTokenForAuthId: creating unsigned JWT for authId=$authId subject=${subjectServiceAccountMail ?? issuerAccountMail} issuer=$issuerAccountMail targetUrl=$targetUrl',
+      );
       final jwt = _createUnsignedJWTForAuthId(
         authId,
         subjectServiceAccountMail ?? issuerAccountMail,
         issuerAccountMail,
+        targetUrl: targetUrl,
+      );
+      // ignore: avoid_print
+      print(
+        '[YustAuthService] getAuthTokenForAuthId: signing JWT with RSA private key',
       );
       final signedJwt = jwt.sign(
         RSAPrivateKey(serviceAccountKey['private_key']),
         algorithm: JWTAlgorithm.RS256,
         expiresIn: const Duration(seconds: 3600),
       );
+      // ignore: avoid_print
+      print(
+        '[YustAuthService] getAuthTokenForAuthId: signed custom token with SA key file',
+      );
       return signedJwt;
     } else {
       try {
+        // ignore: avoid_print
+        print(
+          '[YustAuthService] getAuthTokenForAuthId: fetching SA email from metadata server',
+        );
         final metadataEmail = await _getServiceAccountEmailFromMetadata();
+        // ignore: avoid_print
+        print(
+          '[YustAuthService] getAuthTokenForAuthId: using IAM path, metadata email=$metadataEmail',
+        );
         subjectServiceAccountMail ??= metadataEmail;
         issuerAccountMail = metadataEmail;
 
         final iamClient = IAMCredentialsApi(Yust.authClient!);
         final delegate =
             'projects/-/serviceAccounts/$subjectServiceAccountMail';
-        final signRequest = SignJwtRequest(
-          payload: jsonEncode({
-            'uid': authId,
-            'iss': issuerAccountMail,
-            'sub': subjectServiceAccountMail,
-            'aud':
-                'https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit',
-            'iat': DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000,
-            'exp':
-                (DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000) + 3600,
-          }),
+        final payload = jsonEncode({
+          'uid': authId,
+          if (targetUrl != null) 'claims': {'resource': targetUrl},
+          'iss': issuerAccountMail,
+          'sub': subjectServiceAccountMail,
+          'aud':
+              'https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit',
+          'iat': DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000,
+          'exp': (DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000) + 3600,
+        });
+        // ignore: avoid_print
+        print(
+          '[YustAuthService] getAuthTokenForAuthId: calling IAM signJwt delegate=$delegate payload=$payload',
         );
+        final signRequest = SignJwtRequest(payload: payload);
         final SignJwtResponse signingResponse;
         try {
           signingResponse = await iamClient.projects.serviceAccounts.signJwt(
@@ -355,7 +407,10 @@ class YustAuthService {
         if (signedJwt == null) {
           throw YustException('Could not sign JWT');
         }
-
+        // ignore: avoid_print
+        print(
+          '[YustAuthService] getAuthTokenForAuthId: IAM signed custom token successfully',
+        );
         return signedJwt;
       } catch (e) {
         throw YustException(
@@ -369,8 +424,43 @@ class YustAuthService {
     throw UnsupportedError('Not supported. No UI available.');
   }
 
-  Future<String?> getJWTToken() async {
-    throw UnsupportedError('Not supported. No UI available.');
+  /// Returns a Firebase ID token for the backend service account.
+  ///
+  /// Generates a custom token for [_backendAuthId] and exchanges it for a
+  /// Firebase ID token via [IdentityToolkitApi.signInWithCustomToken].
+  /// Throws [UnsupportedError] if [_backendAuthId] is not set (i.e. when
+  /// running in a Flutter context).
+  ///
+  /// If [targetUrl] is provided, it is embedded as a `resource` claim so the
+  /// token is bound to that URL (validated server-side by the API middleware).
+  Future<String?> getJWTToken({String? targetUrl}) async {
+    // ignore: avoid_print
+    print(
+      '[YustAuthService] getJWTToken: backendAuthId=$_backendAuthId, targetUrl=$targetUrl, pathToServiceAccountJson=$_pathToServiceAccountJson',
+    );
+    if (_backendAuthId == null) {
+      throw UnsupportedError('Not supported. No UI available.');
+    }
+    final customToken = await getAuthTokenForAuthId(
+      _backendAuthId,
+      targetUrl: targetUrl,
+    );
+    // ignore: avoid_print
+    print(
+      '[YustAuthService] getJWTToken: got custom token, exchanging for ID token',
+    );
+    final response = await _api.accounts.signInWithCustomToken(
+      GoogleCloudIdentitytoolkitV1SignInWithCustomTokenRequest(
+        token: customToken,
+        returnSecureToken: true,
+      ),
+    );
+    if (response.idToken == null) {
+      throw YustException('Failed to get ID token from custom token exchange');
+    }
+    // ignore: avoid_print
+    print('[YustAuthService] getJWTToken: successfully obtained ID token');
+    return response.idToken;
   }
 
   Future<bool?> isEmailVerified() async {

--- a/lib/src/services/yust_auth_service_flutter.dart
+++ b/lib/src/services/yust_auth_service_flutter.dart
@@ -17,6 +17,7 @@ class YustAuthService {
     Yust yust, {
     String? emulatorAddress,
     String? pathToServiceAccountJson,
+    String? backendAuthId,
   }) : _fireAuth = FirebaseAuth.instance,
        _yust = yust {
     if (emulatorAddress != null) {
@@ -292,7 +293,7 @@ class YustAuthService {
     }
   }
 
-  Future<String?> getJWTToken() async {
+  Future<String?> getJWTToken({String? targetUrl}) async {
     final jwtObject = await _fireAuth.currentUser?.getIdTokenResult();
     return jwtObject?.token;
   }

--- a/lib/src/services/yust_auth_service_mocked.dart
+++ b/lib/src/services/yust_auth_service_mocked.dart
@@ -51,7 +51,8 @@ class YustAuthServiceMocked implements YustAuthService {
   String? getCurrentUserId() => throw UnimplementedError();
 
   @override
-  Future<String?> getJWTToken() => throw UnimplementedError();
+  Future<String?> getJWTToken({String? targetUrl}) =>
+      throw UnimplementedError();
 
   @override
   Future<void> sendPasswordResetEmail(String email) =>
@@ -101,6 +102,7 @@ class YustAuthServiceMocked implements YustAuthService {
   Future<String> getAuthTokenForAuthId(
     String authId, {
     String? overrideEmail,
+    String? targetUrl,
   }) => throw UnimplementedError();
 
   @override

--- a/lib/src/yust.dart
+++ b/lib/src/yust.dart
@@ -143,7 +143,7 @@ class Yust {
     String? thumbnailCdnBaseUrl,
 
     /// The Firebase Auth uid used by the backend to authenticate its own API
-    /// calls (e.g. backend-to-backend requests). When provided, [getJWTToken]
+    /// calls (e.g. backend-to-backend requests). When provided, `getJWTToken`
     /// generates a Firebase ID token for this uid via custom token exchange
     /// instead of throwing [UnsupportedError]. Leave null in Flutter apps.
     String? backendAuthId,

--- a/lib/src/yust.dart
+++ b/lib/src/yust.dart
@@ -141,6 +141,12 @@ class Yust {
     AccessCredentials? credentials,
     String? originalCdnBaseUrl,
     String? thumbnailCdnBaseUrl,
+
+    /// The Firebase Auth uid used by the backend to authenticate its own API
+    /// calls (e.g. backend-to-backend requests). When provided, [getJWTToken]
+    /// generates a Firebase ID token for this uid via custom token exchange
+    /// instead of throwing [UnsupportedError]. Leave null in Flutter apps.
+    String? backendAuthId,
   }) async {
     if (forUI) _instance = this;
 
@@ -177,6 +183,7 @@ class Yust {
       this,
       emulatorAddress: emulatorAddress,
       pathToServiceAccountJson: pathToServiceAccountJson,
+      backendAuthId: backendAuthId,
     );
     Yust.fileService = YustFileService(
       authClient: Yust.authClient,


### PR DESCRIPTION
## Summary

- Adds `backendAuthId` parameter to `YustAuthService` (Dart) and `Yust.initialize()`
- When set, `getJWTToken()` generates a Firebase ID token for the given authId via custom token exchange (`getAuthTokenForAuthId` → `signInWithCustomToken`) instead of throwing `UnsupportedError`
- `getAuthTokenForAuthId` and `_createUnsignedJWTForAuthId` accept an optional `targetUrl`, embedded as a `claims.resource` custom claim (Firebase copies it to the resulting ID token)
- Flutter auth service accepts `targetUrl` for API symmetry but ignores it (Firebase ID tokens cannot carry custom per-request claims)

Used by: https://github.com/univelop/univelop/pull/7144

## Test plan

- [ ] Backend calls to internal API endpoints succeed without "no UI available"
- [ ] `resource` claim in resulting ID token matches the target URL
- [ ] Flutter auth flow unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)