### PR TITLE
Add PITR recovery db to mocked database service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# yust
+Firebase integration library for Dart/Flutter. Type-safe, reactive Firestore access with multi-tenancy, offline persistence, and platform abstraction (Flutter client + Dart server).
+
+## Structure
+`lib/src/models/` (YustDoc, YustDocSetup, YustFilter, YustUser, YustFile), `lib/src/services/` (database, auth, file, push — each with interface + platform-specific implementations), `lib/src/util/` (helpers, transforms, exceptions).
+
+## Core Abstractions
+- **YustDoc** — Base document class. Auto-tracks timestamps, audit trail, multi-tenancy (`envId`), change detection (`updateMask`).
+- **YustDocSetup\<T\>** — Collection config: `collectionName`, `fromJson`, `forEnvironment`, `hasOwner`, `hasAuthor`, `onInit`, `onSave`.
+- **YustFilter** — Query conditions: 12 comparators (equal, arrayContains, inList, etc.), nested field paths, client-side evaluation.
+- **IYustDatabaseService** — Full CRUD + streams + transactions + aggregations + chunked reads.
+
+## Platform Implementations
+| Platform | Class | Backend |
+|----------|-------|---------|
+| Flutter | `YustDatabaseServiceFlutter` | `cloud_firestore` (FlutterFire) |
+| Dart server/CLI | `YustDatabaseServiceDart` | `googleapis/firestore` REST API |
+| Testing | `YustDatabaseServiceMocked` | In-memory `Map` |
+
+Conditional import selects implementation automatically.
+
+## Key Features
+- **Multi-tenancy**: `forEnvironment: true` → subcollections per `envId`
+- **Transactions**: `runTransactionForDocument()` with auto-retry (max 200 tries)
+- **Field transforms**: Atomic increment, server timestamp, array operations
+- **Aggregations**: `count()`, `sum()`, `avg()` via Firestore Aggregation API
+- **Chunked streaming**: `getListChunked()` for memory-efficient large dataset processing
+- **Caching**: Flutter has native offline persistence; `getFromCache()` vs `getFromDB()`
+- **Database logging**: `dbLogCallback` for performance tracking
+- **onChange hook**: Global document change handler
+
+## Built-In Models
+`YustUser` (auth + workspaces), `YustAddress`, `YustFile` (storage path + thumbnails), `YustImage`, `YustGeoLocation`, `YustNotification`.
+
+## Initialization
+```dart
+final yust = Yust(forUI: true/false, useSubcollections: true, envCollectionName: 'workspaces');
+await yust.initialize(projectId: '...', firebaseOptions/pathToServiceAccountJson: ...);
+```
+
+## Dependencies
+`cloud_firestore`, `firebase_auth`, `firebase_storage`, `googleapis`, `googleapis_auth`, `firebase_core`, `json_annotation`, `collection`, `intl`, `crypto`.

--- a/lib/src/services/yust_database_service_mocked.dart
+++ b/lib/src/services/yust_database_service_mocked.dart
@@ -51,6 +51,56 @@ class YustDatabaseServiceMocked extends YustDatabaseService
 
   Map<String, List<Map<String, dynamic>>> get db => _db;
 
+  /// Snapshot of [_db] used to serve reads while [readTime] is non-null.
+  ///
+  /// This mirrors Firestore's point-in-time recovery (PITR): production
+  /// callers point a clone of their session at an earlier moment by setting
+  /// `db.readTime`, and reads then return the data as it existed then. In
+  /// the mock we keep a single in-memory snapshot which can be filled via
+  /// [createRecoveryDb]. The recovery db is static so it survives across
+  /// the fresh instances created by `BackendSessionController.clone`.
+  static final MockDB _recoveryDb = {};
+
+  /// Snapshots the current live [_db] into [_recoveryDb], deep-copying every
+  /// document. After this call, any read issued through any
+  /// [YustDatabaseServiceMocked] instance whose [readTime] is set will
+  /// resolve against the snapshot rather than the live db.
+  void createRecoveryDb() {
+    _recoveryDb
+      ..clear()
+      ..addAll(_deepCopyMockDb(_db));
+  }
+
+  /// Clears the PITR recovery db populated by [createRecoveryDb].
+  static void clearRecoveryDb() => _recoveryDb.clear();
+
+  /// Read-only view of the PITR recovery db. Intended for assertions in
+  /// tests that compare the live db against the snapshot.
+  static MockDB get recoveryDb => _recoveryDb;
+
+  static MockDB _deepCopyMockDb(MockDB src) {
+    final result = <String, List<Map<String, dynamic>>>{};
+    for (final entry in src.entries) {
+      result[entry.key] = entry.value
+          .map(
+            (e) => Map<String, dynamic>.from(jsonDecode(jsonEncode(e)) as Map),
+          )
+          .toList();
+    }
+    return result;
+  }
+
+  /// Read-side accessor for a collection. When [readTime] is set, returns
+  /// the snapshot from [_recoveryDb]; otherwise returns the live [_db]
+  /// collection (auto-creating it). Writes always go through
+  /// [_getJSONCollection] directly so they never touch the recovery db.
+  List<Map<String, dynamic>> _getReadCollection(String collectionName) {
+    if (readTime != null) {
+      return _recoveryDb[collectionName] ?? const <Map<String, dynamic>>[];
+    }
+    return _getJSONCollection(collectionName);
+  }
+
   @override
   T initDoc<T extends YustDoc>(YustDocSetup<T> docSetup, [T? doc]) {
     final id = _createDocumentId();
@@ -119,7 +169,7 @@ class YustDatabaseServiceMocked extends YustDatabaseService
     List<YustFilter>? filters,
     List<YustOrderBy>? orderBy,
   }) async {
-    var jsonDocs = _getJSONCollection(docSetup.collectionName);
+    var jsonDocs = _getReadCollection(docSetup.collectionName);
     jsonDocs = _filter(jsonDocs, filters);
     jsonDocs = _orderBy(jsonDocs, orderBy);
     final docs = _jsonListToDocList(jsonDocs, docSetup);
@@ -563,7 +613,7 @@ class YustDatabaseServiceMocked extends YustDatabaseService
 
   List<T> _getCollection<T extends YustDoc>(YustDocSetup<T> docSetup) {
     return _jsonListToDocList(
-      _getJSONCollection(docSetup.collectionName),
+      _getReadCollection(docSetup.collectionName),
       docSetup,
     );
   }
@@ -688,7 +738,7 @@ class YustDatabaseServiceMocked extends YustDatabaseService
     String? startAfterDocumentId,
     bool forAllEnvironments = false,
   }) {
-    var jsonDocs = _getJSONCollection(docSetup.collectionName);
+    var jsonDocs = _getReadCollection(docSetup.collectionName);
 
     // Apply static filters (envId) only if not querying all environments
     if (!forAllEnvironments) {


### PR DESCRIPTION
## Summary

- Adds an in-memory snapshot mechanism to `YustDatabaseServiceMocked` that mirrors Firestore's point-in-time recovery (PITR), so tests can exercise restore scripts end-to-end against the mock.
- `createRecoveryDb()` snapshots the live `_db`. While `readTime` is set on any instance, reads resolve against the snapshot (writes always go to the live db).
- The snapshot is static, so it survives across the fresh `dbService` instances created by `BackendSessionController.clone()` — exactly the cloning pattern the production restore scripts rely on.
- Adds `CLAUDE.md` describing the package layout.

## API

```dart
final db = controller.stateSnap.yust.dbService as YustDatabaseServiceMocked;
db.createRecoveryDb();           // snapshot live db
// ... mutate / destroy data ...
clone.db.readTime = recoveryPoint; // any clone reads the snapshot
YustDatabaseServiceMocked.recoveryDb;       // static read-only view
YustDatabaseServiceMocked.clearRecoveryDb(); // reset between tests
```

## Test plan

- [ ] Existing yust tests pass (no behavior change when `readTime == null`).
- [ ] In a downstream consumer (univelop), use the new API to snapshot, mutate the live db, then verify reads with `readTime` set return the snapshot.
- [ ] Verify writes never touch `_recoveryDb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)