### PR TITLE
fix: preserve empty maps when reading from Firestore REST API

### DIFF
--- a/lib/src/services/yust_database_service_dart.dart
+++ b/lib/src/services/yust_database_service_dart.dart
@@ -1600,9 +1600,14 @@ class YustDatabaseService implements IYustDatabaseService {
           isUtc: true,
         ).toIso8601StringWithOffset();
       }
+      // Firestore omits the `fields` key in the REST response for empty
+      // MapValues, so `map` is null even though the field IS a map. Mirror
+      // the `?? []` fallback that arrayValue already has — preserves empty
+      // maps instead of collapsing them to null. A real null field lands in
+      // the `nullValue` branch below, not here.
       return map?.map(
-        (key, childValue) => MapEntry(key, _dbValueToValue(childValue)),
-      );
+            (key, childValue) => MapEntry(key, _dbValueToValue(childValue)),
+          ) ?? {};
     } else if (dbValue.booleanValue != null) {
       return dbValue.booleanValue;
     } else if (dbValue.integerValue != null) {


### PR DESCRIPTION
Firestore omits the `fields` key in the REST response for empty MapValues, causing `_dbValueToValue` to return null instead of {}. This mirrors the `?? []` fallback that arrayValue already has, restoring symmetry between map and array handling.

Without this fix, an empty map field round-tripped through YustDart gets silently converted to null on the next save, causing crashes in downstream code that expects a map.