### PR TITLE
fix: await useAuthEmulator before completing Yust.initialize

### DIFF
--- a/lib/src/services/yust_auth_service_dart.dart
+++ b/lib/src/services/yust_auth_service_dart.dart
@@ -20,6 +20,11 @@ class YustAuthService {
   final Yust _yust;
   final ServiceAccountCredentials? _credentials;
 
+  /// Resolves once the service is ready. On Dart there is nothing async to
+  /// wait for, so this is always already completed — kept here to match the
+  /// Flutter-side API used in [Yust.initialize].
+  final Future<void> ready = Future.value();
+
   /// The Firebase Auth ID (uid) used to generate tokens for backend-to-backend
   /// API calls. When set, [getJWTToken] signs in as this user via a custom
   /// token exchange instead of throwing [UnsupportedError].

--- a/lib/src/services/yust_auth_service_flutter.dart
+++ b/lib/src/services/yust_auth_service_flutter.dart
@@ -15,19 +15,25 @@ class YustAuthService {
   late final FirebaseAuth _fireAuth;
   late final Yust _yust;
 
+  /// Resolves once any emulator wiring has been applied. Callers that perform
+  /// auth operations during initialization must await this — `useAuthEmulator`
+  /// returns a Future that the constructor cannot await, and on web the
+  /// underlying JS `connectAuthEmulator` does not take effect synchronously.
+  final Future<void> ready;
+
   YustAuthService(
     Yust yust, {
     String? emulatorAddress,
     ServiceAccountCredentials? credentials,
     String? backendAuthId,
-  }) : _fireAuth = FirebaseAuth.instance,
-       _yust = yust {
-    if (emulatorAddress != null) {
-      _fireAuth.useAuthEmulator(emulatorAddress, 9099);
-    }
+  }) : ready = emulatorAddress != null
+           ? FirebaseAuth.instance.useAuthEmulator(emulatorAddress, 9099)
+           : Future.value() {
+    _fireAuth = FirebaseAuth.instance;
+    _yust = yust;
   }
 
-  YustAuthService.mocked(Yust yust) {
+  YustAuthService.mocked(Yust yust) : ready = Future.value() {
     throw UnsupportedError('Not supported in Flutter Environment');
   }
 

--- a/lib/src/services/yust_auth_service_mocked.dart
+++ b/lib/src/services/yust_auth_service_mocked.dart
@@ -7,6 +7,9 @@ import 'yust_auth_service.dart';
 class YustAuthServiceMocked implements YustAuthService {
   final Yust _yust;
 
+  @override
+  final Future<void> ready = Future.value();
+
   YustAuthServiceMocked(Yust yust) : _yust = yust;
 
   @override

--- a/lib/src/yust.dart
+++ b/lib/src/yust.dart
@@ -190,6 +190,9 @@ class Yust {
       credentials: credentials,
       backendAuthId: backendAuthId,
     );
+    // On web, `useAuthEmulator` is async — sign-ins started before it
+    // resolves will hit production endpoints.
+    await Yust.authService.ready;
     Yust.fileService = YustFileService(
       authClient: authClient,
       emulatorAddress: emulatorAddress,


### PR DESCRIPTION
## Summary
- `FirebaseAuth.useAuthEmulator(host, port)` returns a `Future<void>`; on web the underlying JS `connectAuthEmulator` doesn't take effect synchronously, so auth calls (e.g. `signInWithMicrosoft`) started before that future resolves hit **production** endpoints instead of the emulator.
- Exposes a `ready` future on `YustAuthService` and awaits it from `Yust.initialize`, so callers can rely on the emulator being fully wired by the time initialization returns.
- The Dart-only and mocked variants get a no-op `ready` to keep the interface symmetric.

## Test plan
- [ ] In a Flutter web host app that calls `Yust.initialize(emulatorAddress: 'localhost', ...)`, federated sign-ins (Microsoft/Google) now hit `http://localhost:9099/emulator/auth/handler...` instead of the production OAuth handler at `<authDomain>/__/auth/handler`.
- [ ] In a Dart-only host (e.g. backend services), `Yust.initialize` still completes immediately — `ready` is a pre-completed `Future.value()` there.
- [ ] Mocked tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)