### PR TITLE
feat(mock): alias __name__ to id in mocked _orderBy

### DIFF
--- a/lib/src/services/yust_database_service_mocked.dart
+++ b/lib/src/services/yust_database_service_mocked.dart
@@ -652,9 +652,18 @@ class YustDatabaseServiceMocked extends YustDatabaseService
     List<YustOrderBy>? orderBy,
   ) {
     for (final o in (orderBy ?? []).reversed) {
+      // Firestore addresses the document ID via the reserved `__name__`
+      // field. Yust stores document IDs in the `id` field on every
+      // YustDoc, so alias `__name__` → `id` here to mirror Firestore's
+      // behavior. Enables tests that append `__name__` as a stable
+      // pagination tiebreaker (as `_getListLazyChunked` does internally,
+      // and as callers of `getListFromDB` should for correct cursor
+      // advancement).
+      final field = o.field == '__name__' ? 'id' : o.field;
       collection.sort((a, b) {
-        final compare = (_readValueInJsonDoc(a, o.field) as Comparable)
-            .compareTo(_readValueInJsonDoc(b, o.field) as Comparable);
+        final compare = (_readValueInJsonDoc(a, field) as Comparable).compareTo(
+          _readValueInJsonDoc(b, field) as Comparable,
+        );
         final order = o.descending ? -1 : 1;
         return order * compare;
       });


### PR DESCRIPTION
## Summary

The mocked `YustDatabaseService._orderBy` reads the field value via `_readValueInJsonDoc`, which returns `null` for the reserved `__name__` field name — sorting by `__name__` then blows up on the `.compareTo` call.

Aliases `__name__` → `id` in the mock so tests can freely add `__name__` as a stable pagination tiebreaker (the same pattern `_getListLazyChunked` already uses internally, and the same alias the REST impl does via `Cursor` construction at `yust_database_service_dart.dart:1330-1355`).

## Why now

Univelop's Records API v2 pagination fix appends `__name__` as a tiebreaker to the orderBy sent to `getListFromDB`, mirroring the chunked-path pattern. That change makes uni_api pagination correct against real Firestore but breaks against the mocked DB — this small alias closes the parity gap.

Isolated from univelop/yust#419 (the paired `getListFromDB` cursor fix) — this one only touches the mock, so it can land and release independently.

## Test plan

- [x] `dart analyze` clean
- [ ] Verified end-to-end via Univelop's paginated record test suite once the univelop hotfix PR pins yust to this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)