### PR TITLE
Apply customAuthDomain on iOS for OAuth sign-in

### DIFF
--- a/lib/src/util/google_cloud_helpers_flutter.dart
+++ b/lib/src/util/google_cloud_helpers_flutter.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 import 'package:googleapis_auth/googleapis_auth.dart';
@@ -27,6 +28,21 @@ class GoogleCloudHelpers {
       }
       final options = fromMap(firebaseOptions);
       await Firebase.initializeApp(options: options);
+    }
+
+    // On iOS release we initialize without FirebaseOptions (see above), so the
+    // configured authDomain never reaches Firebase Auth. Apply it explicitly
+    // via customAuthDomain so OAuth (signInWithProvider) uses our self-hosted,
+    // same-site auth handler instead of the shared *.firebaseapp.com domain,
+    // which Safari's cross-site tracking prevention partitions — breaking
+    // signInWithProvider with "missing initial state". Set unconditionally on
+    // iOS (harmless when it matches the default) to cover both build modes.
+    final authDomain = firebaseOptions?['authDomain'];
+    if (!kIsWeb &&
+        Platform.isIOS &&
+        authDomain != null &&
+        authDomain.isNotEmpty) {
+      FirebaseAuth.instance.customAuthDomain = authDomain;
     }
 
     // Only use emulator when emulatorAddress is provided

--- a/lib/src/util/google_cloud_helpers_flutter.dart
+++ b/lib/src/util/google_cloud_helpers_flutter.dart
@@ -34,12 +34,13 @@ class GoogleCloudHelpers {
     // configured authDomain never reaches Firebase Auth. Apply it explicitly
     // via customAuthDomain so OAuth (signInWithProvider) uses our self-hosted,
     // same-site auth handler instead of the shared *.firebaseapp.com domain,
-    // which Safari's cross-site tracking prevention partitions — breaking
-    // signInWithProvider with "missing initial state". Set unconditionally on
-    // iOS (harmless when it matches the default) to cover both build modes.
+    // whose storage the in-app browser partitions — breaking signInWithProvider
+    // with "missing initial state" (Safari ITP on iOS; also affects Android).
+    // Set on both mobile platforms (harmless when it matches the options value)
+    // to cover the iOS-release no-options path and keep behaviour uniform.
     final authDomain = firebaseOptions?['authDomain'];
     if (!kIsWeb &&
-        Platform.isIOS &&
+        (Platform.isIOS || Platform.isAndroid) &&
         authDomain != null &&
         authDomain.isNotEmpty) {
       FirebaseAuth.instance.customAuthDomain = authDomain;


### PR DESCRIPTION
## Summary

Apply the configured `authDomain` to Firebase Auth on iOS via `FirebaseAuth.instance.customAuthDomain` after initialization.

**Why:** native `signInWithProvider` on iOS reuses Firebase's web `__/auth/handler`, which keeps its flow state in `sessionStorage`. On the shared `*.firebaseapp.com` authDomain, Safari's Prevent Cross-Site Tracking partitions that storage and OAuth (e.g. Microsoft) fails with "Unable to process request due to missing initial state". Pointing iOS at a same-site custom auth handler avoids this.

On iOS **release** builds, `initializeFirebase` calls `Firebase.initializeApp()` **without** `FirebaseOptions`, so the `authDomain` from options never reaches Firebase Auth. This sets it explicitly. Scoped to iOS; Android/web unchanged.

The consuming app (univelop) supplies `<domain>/custom` as the `authDomain` and references this branch via git ref (univelop#7681) until this is merged & released.

## Changes

- `google_cloud_helpers_flutter.dart`: after Firebase init, set `FirebaseAuth.instance.customAuthDomain` from `firebaseOptions['authDomain']` when `Platform.isIOS`.
- Adds `firebase_auth` import (already a dependency).

## Testing

- `dart analyze` clean.
- Verified end-to-end via univelop TestFlight (Microsoft sign-in).
