### PR TITLE
Provision YustUser after OAuth redirect sign-in (completeSignInWithRedirect)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.35.0 - 2026-07-18
+
+- Add `completeSignInWithRedirect` to the auth service. On web, OAuth sign-in with `redirect: true` reloads the page on return from the provider, discarding the in-flight `signInWith...` call before it can provision a `YustUser` — leaving an authenticated Firebase user with no matching `YustUser`. Call `completeSignInWithRedirect` once at app startup to fetch the pending redirect result and create/link the `YustUser`. No-op when there is no pending redirect (safe to call on every startup) and on non-web platforms.
+
 ## 3.33.2 - 2026-05-18
 
 - Fix handling of empty maps in `YustDatabaseService` (dart-only)

--- a/lib/src/services/yust_auth_service_dart.dart
+++ b/lib/src/services/yust_auth_service_dart.dart
@@ -94,6 +94,10 @@ class YustAuthService {
     throw UnsupportedError('Not supported. No UI available.');
   }
 
+  /// Completes an OAuth redirect sign-in. Web-only concept; on the server this
+  /// is a no-op so shared code can call it unconditionally.
+  Future<YustUser?> completeSignInWithRedirect() async => null;
+
   /// Sign out the current user.
   Future<void> signOut() async {
     throw UnsupportedError('Not supported. No UI available.');

--- a/lib/src/services/yust_auth_service_flutter.dart
+++ b/lib/src/services/yust_auth_service_flutter.dart
@@ -119,6 +119,42 @@ class YustAuthService {
       provider,
       redirect: redirect,
     );
+    return _provisionYustUser(userCredential, method);
+  }
+
+  /// Completes an OAuth sign-in that was started with `redirect: true` on web.
+  ///
+  /// The redirect flow navigates the whole page away to the identity provider
+  /// and reloads the app on return, which discards the in-flight
+  /// `signInWith...` call before it can provision a [YustUser]. Firebase
+  /// restores the auth user from persistence on reload, but the [YustUser]
+  /// document would otherwise never be created — leaving an authenticated
+  /// Firebase user with no matching domain user.
+  ///
+  /// Call this once at app startup (web only). It fetches the pending redirect
+  /// result and, if a sign-in just completed, creates or links the matching
+  /// [YustUser]. It is a no-op when there is no pending redirect result, so it
+  /// is safe to call on every startup.
+  Future<YustUser?> completeSignInWithRedirect() async {
+    if (!kIsWeb) return null;
+    final userCredential = await _fireAuth.getRedirectResult();
+    if (userCredential.user == null) return null;
+    final method = _methodFromProviderId(
+      userCredential.additionalUserInfo?.providerId ??
+          userCredential.credential?.providerId,
+    );
+    return _provisionYustUser(userCredential, method);
+  }
+
+  /// Ensures a [YustUser] exists for the signed-in [userCredential], linking
+  /// an existing user (matched by email) or creating a new one. Returns the
+  /// created user, or `null` when the sign-in failed or a matching user
+  /// already existed / was linked. Idempotent — safe to call for a user that
+  /// is already provisioned.
+  Future<YustUser?> _provisionYustUser(
+    UserCredential userCredential,
+    YustAuthenticationMethod? method,
+  ) async {
     if (_signInFailed(userCredential)) return null;
     final connectedYustUser = await _maybeGetConnectedYustUser(userCredential);
     if (_yustUserWasLinked(connectedYustUser)) return null;
@@ -144,6 +180,23 @@ class YustAuthService {
       authId: _getId(userCredential),
       authenticationMethod: method,
     );
+  }
+
+  YustAuthenticationMethod? _methodFromProviderId(String? providerId) {
+    switch (providerId) {
+      case 'microsoft.com':
+        return YustAuthenticationMethod.microsoft;
+      case 'google.com':
+        return YustAuthenticationMethod.google;
+      case 'apple.com':
+        return YustAuthenticationMethod.apple;
+      case null:
+      case 'password':
+      case 'firebase':
+        return null;
+      default:
+        return YustAuthenticationMethod.openId;
+    }
   }
 
   String _getId(UserCredential userCredential) => userCredential.user!.uid;

--- a/lib/src/services/yust_auth_service_mocked.dart
+++ b/lib/src/services/yust_auth_service_mocked.dart
@@ -89,6 +89,9 @@ class YustAuthServiceMocked implements YustAuthService {
   }) => throw UnimplementedError();
 
   @override
+  Future<YustUser?> completeSignInWithRedirect() async => null;
+
+  @override
   Future<void> signOut() => throw UnimplementedError();
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: yust
 description: Build awesome apps with Flutter and Firebase - this package allows communication with Firebase to be a breeze.
-version: 3.33.2
+version: 3.35.0
 homepage: https://github.com/univelop/yust
 
 environment:


### PR DESCRIPTION
## Problem

On web, OAuth sign-in with `redirect: true` uses Firebase's `signInWithRedirect`, which navigates the whole page away to the identity provider and **reloads the app on return**. That reload discards the in-flight `signInWith...` call before it reaches the link/create logic, so `_signInWithProvider` never provisions a `YustUser`. Firebase restores the `AuthUser` from persistence, but the `YustUser` document is never created — leaving an authenticated Firebase user with no matching domain user.

This surfaced in the app as: **Microsoft login on dev creates only an AuthUser, not a proper YustUser** (dev/next/beta web use the redirect flow; prod uses popup and is unaffected).

## Change

- Add **`completeSignInWithRedirect()`** to the auth service. On web it calls `getRedirectResult()` and, when a sign-in just completed, links or creates the matching `YustUser` (auth method derived from the provider id). It is a **no-op** when there is no pending redirect result (safe to call on every startup) and on non-web platforms.
- Extract the shared link/create logic into `_provisionYustUser`, reused by both `_signInWithProvider` and the new method.
- Add matching no-op `completeSignInWithRedirect()` overrides on the **dart** (server) and **mocked** services for interface parity.

Callers invoke `completeSignInWithRedirect()` once at app startup. The univelop side is in univelop#(see linked app PR).

## Notes

- Idempotent: if the redirect user already has a `YustUser` (matched by `authId`), no duplicate is created.
- Version bumped to `3.35.0`. (origin/master was at `3.33.2`; there is unpublished local `3.34.0` WIP on some checkouts — this intentionally lands as `3.35.0` to avoid colliding with it and to match the app's `^3.35.0` constraint.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
