### PR TITLE
Clean update mask paths that are missing from the saved data

### DIFF
--- a/lib/src/services/yust_database_service_dart.dart
+++ b/lib/src/services/yust_database_service_dart.dart
@@ -847,6 +847,14 @@ class YustDatabaseService implements IYustDatabaseService {
     if (updateMask != null) updateMask.addAll(yustUpdateMask);
 
     final jsonDoc = doc.toJson();
+
+    if (updateMask != null) {
+      final cleaned = cleanUpdateMask(jsonDoc, updateMask);
+      updateMask
+        ..clear()
+        ..addAll(cleaned);
+    }
+
     final dbDoc = Document(
       fields: jsonDoc.map(
         (key, value) => MapEntry(key, _valueToDbValue(value)),
@@ -1225,9 +1233,10 @@ class YustDatabaseService implements IYustDatabaseService {
     );
     if (useUpdateMask) {
       write.updateMask = DocumentMask(
-        fieldPaths: doc.updateMask
-            .map((e) => YustHelpers().toQuotedFieldPath(e)!)
-            .toList(),
+        fieldPaths: cleanUpdateMask(
+          jsonDoc,
+          doc.updateMask,
+        ).map((e) => YustHelpers().toQuotedFieldPath(e)!).toList(),
       );
     }
     final commitRequest = CommitRequest(

--- a/lib/src/services/yust_database_service_flutter.dart
+++ b/lib/src/services/yust_database_service_flutter.dart
@@ -450,6 +450,13 @@ class YustDatabaseService implements IYustDatabaseService {
 
     final jsonDoc = doc.toJson();
 
+    if (updateMask != null) {
+      final cleaned = cleanUpdateMask(jsonDoc, updateMask);
+      updateMask
+        ..clear()
+        ..addAll(cleaned);
+    }
+
     final modifiedDoc = _prepareJsonForFirebase(
       doNotCreate && updateMask != null
           ? _getValuesByUpdateMask(jsonDoc, updateMask)

--- a/lib/src/services/yust_database_service_shared.dart
+++ b/lib/src/services/yust_database_service_shared.dart
@@ -36,6 +36,44 @@ Future<void> prepareSaveDoc<T extends YustDoc>(
   if (!skipOnSave) await docSetup.onSave?.call(doc);
 }
 
+/// Cleans a Firestore update field [mask] so it never references a path that is
+/// missing from [data].
+List<String> cleanUpdateMask(Map<String, dynamic> data, Iterable<String> mask) {
+  final resolved = <String>{};
+  for (final path in mask) {
+    final existing = _nearestExistingPath(data, path);
+    if (existing != null) resolved.add(existing);
+  }
+
+  // Drop any path that has a strict ancestor also present in the mask.
+  return resolved
+      .where(
+        (path) => !resolved.any(
+          (other) => other != path && path.startsWith('$other.'),
+        ),
+      )
+      .toList();
+}
+
+/// Returns the longest prefix of [path] that resolves to an existing key in
+/// [data] (the resolved value may itself be `null`), or `null` if not even the
+/// first segment exists. Backtick-quoting of segments is tolerated.
+String? _nearestExistingPath(Map<String, dynamic> data, String path) {
+  final segments = path.split('.');
+  final kept = <String>[];
+  dynamic current = data;
+  for (final segment in segments) {
+    final key = segment.replaceAll('`', '');
+    if (current is Map<String, dynamic> && current.containsKey(key)) {
+      kept.add(segment);
+      current = current[key];
+    } else {
+      break;
+    }
+  }
+  return kept.isEmpty ? null : kept.join('.');
+}
+
 T doInitDoc<T extends YustDoc>(YustDocSetup<T> docSetup, String id, [T? doc]) {
   if (docSetup.newDoc == null) {
     throw YustException(

--- a/test/services/yust_database_service_shared_test.dart
+++ b/test/services/yust_database_service_shared_test.dart
@@ -1,0 +1,121 @@
+import 'package:test/test.dart';
+import 'package:yust/src/services/yust_database_service_shared.dart';
+
+void main() {
+  group('cleanUpdateMask', () {
+    test(
+      'drops stale nested paths when the field was cleared to null (map→null)',
+      () {
+        final data = {
+          'brickValues': {'f3VOLnWX': null},
+        };
+        final mask = [
+          'brickValues.f3VOLnWX.selectedId',
+          'brickValues.f3VOLnWX.labelMl.de',
+          'brickValues.f3VOLnWX',
+        ];
+
+        expect(
+          cleanUpdateMask(data, mask),
+          unorderedEquals(['brickValues.f3VOLnWX']),
+        );
+      },
+    );
+
+    test('collapses a pure child path to the nearest existing ancestor', () {
+      final data = {
+        'brickValues': {'f3VOLnWX': null},
+      };
+      final mask = ['brickValues.f3VOLnWX.selectedId'];
+
+      expect(
+        cleanUpdateMask(data, mask),
+        unorderedEquals(['brickValues.f3VOLnWX']),
+      );
+    });
+
+    test('collapses overlapping ancestor and descendant paths', () {
+      final data = {
+        'a': {
+          'b': {'c': 1},
+        },
+      };
+      final mask = ['a', 'a.b.c'];
+
+      expect(cleanUpdateMask(data, mask), unorderedEquals(['a']));
+    });
+
+    test('keeps a valid nested map mask unchanged', () {
+      final data = {
+        'a': {
+          'b': {'c': 1, 'd': 2},
+        },
+      };
+      final mask = ['a.b.c', 'a.b.d'];
+
+      expect(cleanUpdateMask(data, mask), unorderedEquals(['a.b.c', 'a.b.d']));
+    });
+
+    test('keeps scalar field paths unchanged', () {
+      final data = {'name': 'foo', 'count': 1, 'flag': null};
+      final mask = ['name', 'count', 'flag'];
+
+      expect(
+        cleanUpdateMask(data, mask),
+        unorderedEquals(['name', 'count', 'flag']),
+      );
+    });
+
+    test('keeps a whole-field path when the data holds a map (null→map)', () {
+      final data = {
+        'brickValues': {
+          'f3VOLnWX': {'selectedId': 'status_2'},
+        },
+      };
+      final mask = ['brickValues.f3VOLnWX'];
+
+      expect(
+        cleanUpdateMask(data, mask),
+        unorderedEquals(['brickValues.f3VOLnWX']),
+      );
+    });
+
+    test('drops a path whose first segment does not exist in the data', () {
+      final data = {'name': 'foo'};
+      final mask = ['missing.bar', 'name'];
+
+      expect(cleanUpdateMask(data, mask), unorderedEquals(['name']));
+    });
+
+    test('tolerates backtick-quoted segments', () {
+      final data = {
+        'brickValues': {'0abc': null},
+      };
+      final mask = ['brickValues.`0abc`.selectedId'];
+
+      expect(
+        cleanUpdateMask(data, mask),
+        unorderedEquals(['brickValues.`0abc`']),
+      );
+    });
+
+    test('deduplicates paths that resolve to the same existing ancestor', () {
+      final data = {
+        'brickValues': {'f3VOLnWX': null},
+      };
+      final mask = [
+        'brickValues.f3VOLnWX.selectedId',
+        'brickValues.f3VOLnWX.labelMl.de',
+      ];
+
+      expect(
+        cleanUpdateMask(data, mask),
+        unorderedEquals(['brickValues.f3VOLnWX']),
+      );
+    });
+
+    test('returns an empty mask for an empty input mask', () {
+      expect(cleanUpdateMask({'a': 1}, []), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

A map-valued field that is set and then cleared to `null` in the same save leaves stale nested leaf paths (e.g. `brickValues.X.selectedId`) in the update mask while the data at `brickValues.X` is now `null`. Firestore Web rejects such a mask with

> Field 'brickValues.X.selectedId' is specified in your field mask but missing from your input data.

so `saveDoc` throws and the document is not saved. The REST path (Dart backend) would instead silently delete the field — also wrong.

## Changes

- New shared helper `cleanUpdateMask` in `yust_database_service_shared.dart`:
  - For each mask path: keep it if it resolves to an existing field in the data (value may be `null`); otherwise collapse it to the nearest existing ancestor (so the parent's `null` still gets written), or drop it entirely.
  - Collapse overlapping ancestor/descendant paths (Firestore rejects overlapping field paths) and deduplicate.
- Applied at the DB boundary in both `saveDoc` implementations (Flutter `SetOptions(mergeFields:)` and Dart REST `patch`) and in `commitTransaction` (same masked REST write, same silent-delete risk).

The rule only removes invalid mask paths, so it is behaviour-neutral for already-consistent masks.

## Tests

- New unit tests for `cleanUpdateMask` covering map→null stale paths, ancestor collapsing, overlap/dedup, valid map masks, scalar fields, missing paths, and backtick-quoted segments.
- `dart analyze` and `flutter test` pass (via fvm, Flutter 3.38.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)